### PR TITLE
Added function openPageNoTransition

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -217,5 +217,26 @@
 	}
 
 	init();
+	
+	//changes to a page such as id="page-manuals" without opening the menu and preserving menu transition functionality
+	window.openPageNoTransition = function(id){
 
+		var futurePage = id ? document.getElementById(id) : pages[current],
+			futureCurrent = pages.indexOf(futurePage),
+			stackPagesIdxs = getStackPagesIdxs(futureCurrent);
+
+		// set transforms for the new current page
+		futurePage.style.WebkitTransform = 'translate3d(0, 0, 0)';
+		futurePage.style.transform = 'translate3d(0, 0, 0)';
+		futurePage.style.opacity = 1;
+
+		classie.remove(futurePage, 'page--inactive');
+
+		// set current
+		if( id ) {
+			current = futureCurrent;
+		}
+
+		buildStack();
+	}
 })(window);


### PR DESCRIPTION
This feature allows changing to a page from within a page. Currently, you can only change pages from the menu itself.

Use from javascript example: `window.openPageNoTransition("page-manuals");`

Use from within a page element directly: `<div id='abutton' onclick='window.openPageNoTransition("page-manuals")>Visit Manuals Page</div>`

Many people on the _https://tympanus.net/codrops/2015/10/21/page-stack-navigation/_ comments were requesting this feature.

